### PR TITLE
Fix napari-hub page of the plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,10 @@ name = napari-labeling
 
 author = Tom Burke
 author_email = burke@mpi-cbg.de
+url = https://github.com/Labelings/napari-labeling
 
 license = BSD-3-Clause
-description = A simple plugin to use with napari
+description = A napari plugin for handling overlapping labeling data
 long_description = file: README.md
 long_description_content_type = text/markdown
 include_package_data = True


### PR DESCRIPTION
Hi Tom @tomburke-rse ,

great to see this released! This PR is an attempt to fix broken links on the [napari-hub page](https://www.napari-hub.org/plugins/napari-labeling) of the plugin. I'm not sure if this is the right place as the hub page suggests that the plugin is located under https://github.com/tomburke-rse/napari-labeling but this leads to a 404 error.

After merging this, you need to release a new version to pypi and wait 10 minutes to update the napari-hub page.

Let me know if I can help with anything else. 🌻 

Best,
Robert